### PR TITLE
fix: use spot price when calculating principal before unwrap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,5 @@ jobs:
           forge test -vvv
         env:
           MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+          UNICHAIN_RPC_URL: ${{ secrets.UNICHAIN_RPC_URL }}
         id: test

--- a/script/uniswap/CreateV4Wrappers.s.sol
+++ b/script/uniswap/CreateV4Wrappers.s.sol
@@ -48,15 +48,16 @@ contract CreateV4WrappersScript is Script {
 
         vm.startBroadcast();
 
-        (address uniswapV4Wrapper, address fixedPriceOracleUniswapV4Wrapper) = v4Factory.createUniswapV4Wrapper(
-            address(eulerRouter),
-            unitOfAccount,
-            vaultWrappersPoolKey
-        );
+        (address uniswapV4Wrapper, address fixedPriceOracleUniswapV4Wrapper) =
+            v4Factory.createUniswapV4Wrapper(address(eulerRouter), unitOfAccount, vaultWrappersPoolKey);
 
         //let's also deploy chainlinkInfrequentOracle as well
-        address vaultWrapper0Oracle = createChainlinkInfrequentOracle(vaultWrapper0, ChainlinkInfrequentOracle(eulerRouter.getConfiguredOracle(asset0, unitOfAccount)));
-        address vaultWrapper1Oracle = createChainlinkInfrequentOracle(vaultWrapper1, ChainlinkInfrequentOracle(eulerRouter.getConfiguredOracle(asset1, unitOfAccount)));
+        address vaultWrapper0Oracle = createChainlinkInfrequentOracle(
+            vaultWrapper0, ChainlinkInfrequentOracle(eulerRouter.getConfiguredOracle(asset0, unitOfAccount))
+        );
+        address vaultWrapper1Oracle = createChainlinkInfrequentOracle(
+            vaultWrapper1, ChainlinkInfrequentOracle(eulerRouter.getConfiguredOracle(asset1, unitOfAccount))
+        );
 
         //set the oracles
         eulerRouter.govSetConfig(vaultWrapper0, unitOfAccount, vaultWrapper0Oracle);

--- a/script/uniswap/CreateV4Wrappers.s.sol
+++ b/script/uniswap/CreateV4Wrappers.s.sol
@@ -36,7 +36,7 @@ contract CreateV4WrappersScript is Script {
 
     function run() public {
         // Create instances of the UniswapV4WrapperFactory
-        UniswapV4WrapperFactory v4Factory = UniswapV4WrapperFactory(0x77779400171A3B7d4423554378D600693996a777);
+        UniswapV4WrapperFactory v4Factory = UniswapV4WrapperFactory(0x7777943712740f9877c95411FC0C606C524fc777);
 
         PoolKey memory vaultWrappersPoolKey = PoolKey({
             currency0: vaultWrapper0 < vaultWrapper1 ? Currency.wrap(vaultWrapper0) : Currency.wrap(vaultWrapper1),

--- a/script/uniswap/UniswapWrapperFactoryDeployment.s.sol
+++ b/script/uniswap/UniswapWrapperFactoryDeployment.s.sol
@@ -23,7 +23,7 @@ contract UniswapWrapperFactoryDeploymentScript is Script {
     {
         bytes memory creationCodeWithArgs = abi.encodePacked(creationCode, constructorArgs);
         // console.log("deployer", deployer);
-        // console.logBytes32(keccak256(creationCodeWithArgs));
+        console.logBytes32(keccak256(creationCodeWithArgs));
 
         for (uint256 i = 0; i < type(uint256).max; i++) {
             address computed = computeAddress(deployer, i, creationCodeWithArgs);
@@ -60,7 +60,7 @@ contract UniswapWrapperFactoryDeploymentScript is Script {
         uint256 v4Salt = findVanitySalt(
             CREATE2_FACTORY, type(UniswapV4WrapperFactory).creationCode, abi.encode(evc, v4PositionManager, weth)
         );
-        v4Salt = 89803064614613559128942510503412517851878641377354393196606698967848670379431;
+        v4Salt = 76508893199692067667885840213832328288724823780803052223500390527924915937700;
 
         vm.startBroadcast();
 

--- a/src/uniswap/UniswapV4Wrapper.sol
+++ b/src/uniswap/UniswapV4Wrapper.sol
@@ -115,7 +115,8 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
         TokensOwed memory feesOwed = tokensOwed[tokenId];
 
         {
-            PositionState memory positionState = _getPositionState(tokenId);
+            // Here we are using the pool's spot price to calculate how much the liquidity is worth in underlying tokens
+            PositionState memory positionState = _getPositionState(tokenId, true);
             uint128 liquidityToRemove =
                 proportionalShare(positionState.liquidity, amount, totalSupplyOfTokenId).toUint128();
             (amount0, amount1) = _principal(positionState, liquidityToRemove);
@@ -152,11 +153,13 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
     }
 
     /// @notice Calculates the proportional value of a position in unit of account terms
+    /// @dev This calculation disregards the current pool spot price and instead uses the oracle price
+    ///      to determine how much the liquidity position is worth
     /// @param tokenId The ID of the position token to evaluate
     /// @param amount The proportion of the position to value
     /// @return the proportional value of the specified position in unit of account
     function calculateValueOfTokenId(uint256 tokenId, uint256 amount) public view override returns (uint256) {
-        PositionState memory positionState = _getPositionState(tokenId);
+        PositionState memory positionState = _getPositionState(tokenId, false);
 
         (uint256 amount0, uint256 amount1) = _total(positionState, tokenId);
 
@@ -179,17 +182,28 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
     /// @notice Gets the current state of a position
     /// @param tokenId The position token ID
     /// @return positionState The complete position state
-    function _getPositionState(uint256 tokenId) internal view returns (PositionState memory positionState) {
+    function _getPositionState(uint256 tokenId, bool shouldUseSpotPrice)
+        internal
+        view
+        returns (PositionState memory positionState)
+    {
         PositionInfo position = IPositionManager(address(underlying)).positionInfo(tokenId);
         (uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128) = poolManager
             .getPositionInfo(poolId, address(underlying), position.tickLower(), position.tickUpper(), bytes32(tokenId));
+
+        uint160 sqrtRatioX96;
+        if (shouldUseSpotPrice) {
+            (sqrtRatioX96,,,) = poolManager.getSlot0(poolId);
+        } else {
+            sqrtRatioX96 = getSqrtRatioX96(_getCurrencyAddress(currency0), _getCurrencyAddress(currency1), unit0, unit1);
+        }
 
         positionState = PositionState({
             position: position,
             liquidity: liquidity,
             feeGrowthInside0LastX128: feeGrowthInside0LastX128,
             feeGrowthInside1LastX128: feeGrowthInside1LastX128,
-            sqrtRatioX96: getSqrtRatioX96(_getCurrencyAddress(currency0), _getCurrencyAddress(currency1), unit0, unit1)
+            sqrtRatioX96: sqrtRatioX96
         });
     }
 

--- a/src/uniswap/UniswapV4Wrapper.sol
+++ b/src/uniswap/UniswapV4Wrapper.sol
@@ -181,6 +181,7 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
 
     /// @notice Gets the current state of a position
     /// @param tokenId The position token ID
+    /// @param shouldUseSpotPrice If true, uses the current pool spot price; if false, uses the oracle price
     /// @return positionState The complete position state
     function _getPositionState(uint256 tokenId, bool shouldUseSpotPrice)
         internal

--- a/test/helpers/MockUniswapV4Wrapper.sol
+++ b/test/helpers/MockUniswapV4Wrapper.sol
@@ -10,6 +10,8 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {ActionConstants} from "lib/v4-periphery/src/libraries/ActionConstants.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
+///@dev all of the testing uses spot price and not the oracle price
+///In reality, the oracle price is used instead of the pool spot price to calculate how much a liquidity position is worth
 contract MockUniswapV4Wrapper is UniswapV4Wrapper {
     using StateLibrary for IPoolManager;
     using SafeCast for uint256;
@@ -58,12 +60,12 @@ contract MockUniswapV4Wrapper is UniswapV4Wrapper {
     }
 
     function pendingFees(uint256 tokenId) external view returns (uint256 fees0Owed, uint256 fees1Owed) {
-        PositionState memory positionState = _getPositionState(tokenId);
+        PositionState memory positionState = _getPositionState(tokenId, true);
         return _pendingFees(positionState);
     }
 
     function total(uint256 tokenId) external view returns (uint256 amount0Total, uint256 amount1Total) {
-        PositionState memory positionState = _getPositionState(tokenId);
+        PositionState memory positionState = _getPositionState(tokenId, true);
         return _total(positionState, tokenId);
     }
 
@@ -72,7 +74,7 @@ contract MockUniswapV4Wrapper is UniswapV4Wrapper {
         uint256 unwrapAmount,
         uint256 balanceBeforeUnwrap
     ) public view returns (uint256) {
-        PositionState memory positionState = _getPositionState(tokenId);
+        PositionState memory positionState = _getPositionState(tokenId, true);
         uint128 liquidityToRemove =
             proportionalShare(positionState.liquidity, unwrapAmount, totalSupply(tokenId)).toUint128();
 

--- a/test/invariant/BaseSetup.sol
+++ b/test/invariant/BaseSetup.sol
@@ -309,7 +309,7 @@ contract BaseSetup is Test, Fuzzers {
         internal
         returns (uint256 tokenIdMinted, uint256 amount0Spent, uint256 amount1Spent)
     {
-        params.liquidityDelta = bound(params.liquidityDelta, 10e18, 10_000e18);
+        params.liquidityDelta = bound(params.liquidityDelta, 1, 10_000e18);
         (uint160 sqrtRatioX96,,,) = poolManager.getSlot0(poolId);
         params = createFuzzyLiquidityParams(params, poolKey.tickSpacing, sqrtRatioX96);
 

--- a/test/uniswap/UniswapV3Wrapper.t.sol
+++ b/test/uniswap/UniswapV3Wrapper.t.sol
@@ -368,7 +368,8 @@ contract UniswapV3WrapperTest is Test, UniswapBaseTest {
 
         transferAmount = bound(transferAmount, 1 + (totalValueBefore / ALLOWED_PRECISION_IN_TESTS), totalValueBefore); // make sure there is some minimum transfer amount
 
-        uint256 erc6909TokensTransferred = wrapper.normalizedToFull(borrower, tokenId, transferAmount, totalValueBefore); // (transferAmount * wrapper.FULL_AMOUNT()) / totalValueBefore;
+        uint256 tokenIdBalance = wrapper.balanceOf(borrower, tokenId);
+        uint256 erc6909TokensTransferred = wrapper.normalizedToFull(tokenIdBalance, transferAmount, totalValueBefore); // (transferAmount * wrapper.FULL_AMOUNT()) / totalValueBefore;
 
         assertTrue(wrapper.transfer(liquidator, transferAmount));
 

--- a/test/uniswap/UniswapV4Wrapper.t.sol
+++ b/test/uniswap/UniswapV4Wrapper.t.sol
@@ -481,7 +481,8 @@ contract UniswapV4WrapperTest is Test, UniswapBaseTest {
         vm.assume(totalValueBefore > 0);
         transferAmount = bound(transferAmount, 1 + (totalValueBefore / ALLOWED_PRECISION_IN_TESTS), totalValueBefore);
 
-        uint256 erc6909TokensTransferred = wrapper.normalizedToFull(borrower, tokenId, transferAmount, totalValueBefore); // (transferAmount * wrapper.FULL_AMOUNT()) / totalValueBefore;
+        uint256 tokenIdBalance = wrapper.balanceOf(borrower, tokenId);
+        uint256 erc6909TokensTransferred = wrapper.normalizedToFull(tokenIdBalance, transferAmount, totalValueBefore); // (transferAmount * wrapper.FULL_AMOUNT()) / totalValueBefore;
 
         assertTrue(wrapper.transfer(liquidator, transferAmount));
 

--- a/test/uniswap/UniswapV4Wrapper.t.sol
+++ b/test/uniswap/UniswapV4Wrapper.t.sol
@@ -436,14 +436,8 @@ contract UniswapV4WrapperTest is Test, UniswapBaseTest {
         assertEq(currentFees0Owed, expectedFees0 - (expectedFees0 * partialUnwrapAmount) / wrapper.FULL_AMOUNT());
         assertEq(currentFees1Owed, expectedFees1 - (expectedFees1 * partialUnwrapAmount) / wrapper.FULL_AMOUNT());
 
-        assertEq(
-            currency0.balanceOf(address(wrapper)),
-            currentFees0Owed
-        );
-        assertEq(
-            currency1.balanceOf(address(wrapper)),
-            currentFees1Owed
-        );
+        assertEq(currency0.balanceOf(address(wrapper)), currentFees0Owed);
+        assertEq(currency1.balanceOf(address(wrapper)), currentFees1Owed);
 
         //now if a user does full unwrap, feesOwed should be zero and the should have gone to the user itself
         wrapper.unwrap(borrower, tokenIdMinted, borrower);
@@ -510,5 +504,36 @@ contract UniswapV4WrapperTest is Test, UniswapBaseTest {
 
     function test_basicLiquidationV4() public {
         basicLiquidationTest();
+    }
+
+    function testUnwrap_Unichain() public {
+        string memory fork_url = vm.envString("UNICHAIN_RPC_URL");
+        vm.createSelectFork(fork_url, 28206234);
+
+        poolKey = PoolKey({
+            currency0: Currency.wrap(address(0x7b793B1388e14F03e19dc562470e7D25B2Ae9b97)), //WETH
+            currency1: Currency.wrap(address(0x9C383Fa23Dd981b361F0495Ba53dDeB91c750064)), //USDC
+            fee: 18, //0.05% fee
+            tickSpacing: 1,
+            hooks: IHooks(0x777ef319C338C6ffE32A2283F603db603E8F2A80)
+        });
+
+        wrapper = new MockUniswapV4Wrapper{salt: bytes32(uint256(1))}(
+            address(0x2A1176964F5D7caE5406B627Bf6166664FE83c60),
+            address(0x4529A01c7A0410167c5740C487A8DE60232617bf),
+            address(0x4267e3012799A804738A73A2Fa9eB4fD441ceEFF),
+            0x0000000000000000000000000000000000000348,
+            poolKey,
+            Addresses.WETH
+        );
+
+        borrower = 0x69196bC5035cE85C28DAc0c57D0F27f50712A0B2;
+        tokenId = 1428340; // we know this tokenId is worth $7K
+
+        vm.startPrank(borrower);
+        wrapper.underlying().approve(address(wrapper), tokenId);
+        wrapper.wrap(tokenId, borrower);
+        wrapper.unwrap(borrower, tokenId, borrower, wrapper.FULL_AMOUNT(), "");
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
We were using oracle price and that is not inline with the actual decrease liquidity operation on the pool that uses the spot price. The discrepancy between oracle price and pool spot price can be made as big as the attacker wants to gulp all of the fees for themselves if they are not the sole owner of Liquidity Position. For normal users, because we expect that the difference between amountReceived and amount calculated principal is fees, it can underflow and the operation can fail. That's what was happening for the test case [testUnwrap_Unichain](https://github.com/VII-Finance/core-contracts/blob/895f15ffc19d360c471e0ebc1289ce93121f15fe/test/uniswap/UniswapV4Wrapper.t.sol#L509). It now passes because of the bug fix.