### PR TITLE
Feat: add preview unwrap 

### DIFF
--- a/src/uniswap/UniswapV4Wrapper.sol
+++ b/src/uniswap/UniswapV4Wrapper.sol
@@ -116,7 +116,8 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
 
         {
             // Here we are using the pool's spot price to calculate how much the liquidity is worth in underlying tokens
-            PositionState memory positionState = _getPositionState(tokenId, true);
+            (uint160 sqrtRatioX96,,,) = poolManager.getSlot0(poolId);
+            PositionState memory positionState = _getPositionState(tokenId, sqrtRatioX96);
             uint128 liquidityToRemove =
                 proportionalShare(positionState.liquidity, amount, totalSupplyOfTokenId).toUint128();
             (amount0, amount1) = _principal(positionState, liquidityToRemove);
@@ -159,14 +160,15 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
     /// @param amount The proportion of the position to value
     /// @return the proportional value of the specified position in unit of account
     function calculateValueOfTokenId(uint256 tokenId, uint256 amount) public view override returns (uint256) {
-        PositionState memory positionState = _getPositionState(tokenId, false);
+        uint160 sqrtRatioX96 =
+            getSqrtRatioX96(_getCurrencyAddress(currency0), _getCurrencyAddress(currency1), unit0, unit1);
 
-        (uint256 amount0, uint256 amount1) = _total(positionState, tokenId);
+        (uint256 amount0, uint256 amount1) = previewUnwrap(tokenId, sqrtRatioX96, amount);
 
         uint256 amount0InUnitOfAccount = getQuote(amount0, _getCurrencyAddress(currency0));
         uint256 amount1InUnitOfAccount = getQuote(amount1, _getCurrencyAddress(currency1));
 
-        return proportionalShare(amount0InUnitOfAccount + amount1InUnitOfAccount, amount, totalSupply(tokenId));
+        return amount0InUnitOfAccount + amount1InUnitOfAccount;
     }
 
     function previewUnwrap(uint256 tokenId, uint160 sqrtRatioX96, uint256 unwrapAmount)
@@ -174,8 +176,7 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
         view
         returns (uint256 amount0, uint256 amount1)
     {
-        PositionState memory positionState = _getPositionState(tokenId, false);
-        positionState.sqrtRatioX96 = sqrtRatioX96;
+        PositionState memory positionState = _getPositionState(tokenId, sqrtRatioX96);
 
         uint256 totalSupplyOfTokenId = totalSupply(tokenId);
 
@@ -201,9 +202,9 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
 
     /// @notice Gets the current state of a position
     /// @param tokenId The position token ID
-    /// @param shouldUseSpotPrice If true, uses the current pool spot price; if false, uses the oracle price
+    /// @param sqrtRatioX96 The sqrt price ratio to use for calculations
     /// @return positionState The complete position state
-    function _getPositionState(uint256 tokenId, bool shouldUseSpotPrice)
+    function _getPositionState(uint256 tokenId, uint160 sqrtRatioX96)
         internal
         view
         returns (PositionState memory positionState)
@@ -212,13 +213,6 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
         (uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128) = poolManager.getPositionInfo(
             poolId, address(underlying), position.tickLower(), position.tickUpper(), bytes32(tokenId)
         );
-
-        uint160 sqrtRatioX96;
-        if (shouldUseSpotPrice) {
-            (sqrtRatioX96,,,) = poolManager.getSlot0(poolId);
-        } else {
-            sqrtRatioX96 = getSqrtRatioX96(_getCurrencyAddress(currency0), _getCurrencyAddress(currency1), unit0, unit1);
-        }
 
         positionState = PositionState({
             position: position,

--- a/src/uniswap/UniswapV4Wrapper.sol
+++ b/src/uniswap/UniswapV4Wrapper.sol
@@ -177,14 +177,16 @@ contract UniswapV4Wrapper is ERC721WrapperBase {
         PositionState memory positionState = _getPositionState(tokenId, false);
         positionState.sqrtRatioX96 = sqrtRatioX96;
 
+        uint256 totalSupplyOfTokenId = totalSupply(tokenId);
+
         uint128 liquidityToRemove =
-            proportionalShare(positionState.liquidity, unwrapAmount, totalSupply(tokenId)).toUint128();
+            proportionalShare(positionState.liquidity, unwrapAmount, totalSupplyOfTokenId).toUint128();
         (amount0, amount1) = _principal(positionState, liquidityToRemove);
 
         (uint256 pendingFees0, uint256 pendingFees1) = _pendingFees(positionState);
 
-        amount0 += proportionalShare(pendingFees0 + tokensOwed[tokenId].fees0Owed, unwrapAmount, totalSupply(tokenId));
-        amount1 += proportionalShare(pendingFees1 + tokensOwed[tokenId].fees1Owed, unwrapAmount, totalSupply(tokenId));
+        amount0 += proportionalShare(pendingFees0 + tokensOwed[tokenId].fees0Owed, unwrapAmount, totalSupplyOfTokenId);
+        amount1 += proportionalShare(pendingFees1 + tokensOwed[tokenId].fees1Owed, unwrapAmount, totalSupplyOfTokenId);
     }
 
     /// @notice Gets the token ID that was just minted

--- a/test/helpers/IMockUniswapWrapper.sol
+++ b/test/helpers/IMockUniswapWrapper.sol
@@ -23,4 +23,9 @@ interface IMockUniswapWrapper is IERC721WrapperBase, IERC6909TokenSupply {
         external
         view
         returns (uint160 sqrtRatioX96);
+
+    function previewUnwrap(uint256 tokenId, uint160 sqrtRatioX96, uint256 unwrapAmount)
+        external
+        view
+        returns (uint256 amount0, uint256 amount1);
 }

--- a/test/helpers/MockUniswapV3Wrapper.sol
+++ b/test/helpers/MockUniswapV3Wrapper.sol
@@ -45,12 +45,12 @@ contract MockUniswapV3Wrapper is UniswapV3Wrapper {
         view
         returns (uint256 amount0Total, uint256 amount1Total)
     {
-        return _totalPositionValue(sqrtRatioX96, tokenId);
+        return previewUnwrap(tokenId, sqrtRatioX96, totalSupply(tokenId));
     }
 
     function total(uint256 tokenId) external view returns (uint256 amount0Total, uint256 amount1Total) {
         (uint160 sqrtRatioX96,,,,,,) = pool.slot0();
-        return _totalPositionValue(sqrtRatioX96, tokenId);
+        return previewUnwrap(tokenId, sqrtRatioX96, totalSupply(tokenId));
     }
 
     function pendingFees(uint256 tokenId) external view returns (uint256 totalPendingFees0, uint256 totalPendingFees1) {
@@ -78,6 +78,7 @@ contract MockUniswapV3Wrapper is UniswapV3Wrapper {
     }
 
     struct Local {
+        uint160 sqrtRatioX96;
         int24 tickLower;
         int24 tickUpper;
         uint128 liquidity;
@@ -85,9 +86,13 @@ contract MockUniswapV3Wrapper is UniswapV3Wrapper {
         uint256 feeGrowthInside1LastX128;
         uint128 tokensOwed0;
         uint128 tokensOwed1;
-        uint160 sqrtRatioX96;
         uint256 feeGrowthInside0X128;
         uint256 feeGrowthInside1X128;
+        uint256 totalSupplyOfTokenId;
+        uint256 pendingFees0;
+        uint256 pendingFees1;
+        uint256 amount0;
+        uint256 amount1;
     }
 
     function calculateExactedValueOfTokenIdAfterUnwrap(
@@ -95,54 +100,77 @@ contract MockUniswapV3Wrapper is UniswapV3Wrapper {
         uint256 unwrapAmount,
         uint256 balanceBeforeUnwrap
     ) public view returns (uint256) {
-        uint256 totalAmountInUnitOfAccount;
-        {
-            Local memory local;
-            (
-                ,,,,,
-                local.tickLower,
-                local.tickUpper,
-                local.liquidity,
-                local.feeGrowthInside0LastX128,
-                local.feeGrowthInside1LastX128,
-                local.tokensOwed0,
-                local.tokensOwed1
-            ) = INonfungiblePositionManager(address(underlying)).positions(tokenId);
+        // this should be same as previewUnwrap except it should assume that totalSupply has reduced by unwrapAmount
+        // our of total liquidity proportional liquidity has been removed
+        // also proportional tokensOwed has been removed as well
 
-            uint128 liquidityToRemove =
-                proportionalShare(local.liquidity, unwrapAmount, totalSupply(tokenId)).toUint128();
-
-            local.liquidity -= liquidityToRemove;
-
-            (local.sqrtRatioX96,,,,,,) = pool.slot0();
-
-            (uint256 amount0Principal, uint256 amount1Principal) = UniswapPositionValueHelper.principal(
-                local.sqrtRatioX96, local.tickLower, local.tickUpper, local.liquidity
-            );
-
-            (local.feeGrowthInside0X128, local.feeGrowthInside1X128) =
-                _getFeeGrowthInside(local.tickLower, local.tickUpper);
-
-            //fees that are not accounted for yet
-            (uint256 feesOwed0, uint256 feesOwed1) = UniswapPositionValueHelper.feesOwed(
-                local.feeGrowthInside0X128,
-                local.feeGrowthInside1X128,
-                local.feeGrowthInside0LastX128,
-                local.feeGrowthInside1LastX128,
-                local.liquidity
-            );
-
-            totalAmountInUnitOfAccount = getQuote(amount0Principal + feesOwed0 + local.tokensOwed0, token0)
-                + getQuote(amount1Principal + feesOwed1 + local.tokensOwed1, token1);
-        }
-
-        //avoid division by zero
         if (totalSupply(tokenId) == unwrapAmount) {
+            //if we are unwrapping the entire tokenId, then the value after unwrap is zero
             return 0;
         }
-        return proportionalShare(
-            totalAmountInUnitOfAccount, balanceBeforeUnwrap - unwrapAmount, totalSupply(tokenId) - unwrapAmount
+        Local memory local;
+        (local.sqrtRatioX96,,,,,,) = pool.slot0();
+        (
+            ,,,,,
+            local.tickLower,
+            local.tickUpper,
+            local.liquidity,
+            local.feeGrowthInside0LastX128,
+            local.feeGrowthInside1LastX128,
+            local.tokensOwed0,
+            local.tokensOwed1
+        ) = INonfungiblePositionManager(address(underlying)).positions(tokenId);
+
+        // to be exact on how much tokensOwed to reduce by, we calculate total pending fees
+        // and then reduce the tokenOwed by pendingFees + tokensOwed - proportional (pendingFees + tokensOwed) for unwrapAmount
+        (local.feeGrowthInside0X128, local.feeGrowthInside1X128) = _getFeeGrowthInside(local.tickLower, local.tickUpper);
+        // fees that are not accounted for yet for the entire tokenId
+        (local.pendingFees0, local.pendingFees1) = UniswapPositionValueHelper.feesOwed(
+            local.feeGrowthInside0X128,
+            local.feeGrowthInside1X128,
+            local.feeGrowthInside0LastX128,
+            local.feeGrowthInside1LastX128,
+            local.liquidity
         );
+
+        local.tokensOwed0 = (local.pendingFees0.toUint128() + local.tokensOwed0)
+            - proportionalShare(local.pendingFees0 + local.tokensOwed0, unwrapAmount, totalSupply(tokenId)).toUint128();
+        local.tokensOwed1 = (local.pendingFees1.toUint128() + local.tokensOwed1)
+            - proportionalShare(local.pendingFees1 + local.tokensOwed1, unwrapAmount, totalSupply(tokenId)).toUint128();
+
+        local.feeGrowthInside0LastX128 = local.feeGrowthInside0X128;
+        local.feeGrowthInside1LastX128 = local.feeGrowthInside1X128;
+
+        local.liquidity -= proportionalShare(uint256(local.liquidity), unwrapAmount, totalSupply(tokenId)).toUint128();
+
+        local.totalSupplyOfTokenId = totalSupply(tokenId) - unwrapAmount;
+
+        // principal amount but only corresponding to the unwrap amount
+        (local.amount0, local.amount1) = UniswapPositionValueHelper.principal(
+            local.sqrtRatioX96,
+            local.tickLower,
+            local.tickUpper,
+            proportionalShare(uint256(local.liquidity), balanceBeforeUnwrap - unwrapAmount, local.totalSupplyOfTokenId)
+                .toUint128()
+        );
+        // we know that the pending fees will be zero here because it was just realized in the last unwrap. we still calculate it even though we know it's zero
+
+        (local.pendingFees0, local.pendingFees1) = UniswapPositionValueHelper.feesOwed(
+            local.feeGrowthInside0X128,
+            local.feeGrowthInside1X128,
+            local.feeGrowthInside0LastX128,
+            local.feeGrowthInside1LastX128,
+            local.liquidity
+        );
+
+        // we take the proportional share of the pending fees and the tokens owed + principal
+        local.amount0 += proportionalShare(
+            local.pendingFees0 + local.tokensOwed0, balanceBeforeUnwrap - unwrapAmount, local.totalSupplyOfTokenId
+        ); //conditional to avoid division by zero
+        local.amount1 += proportionalShare(
+            local.pendingFees1 + local.tokensOwed1, balanceBeforeUnwrap - unwrapAmount, local.totalSupplyOfTokenId
+        ); //conditional to avoid division by zero if totalSupplyOfTokenId is zero
+        return getQuote(local.amount0, token0) + getQuote(local.amount1, token1);
     }
 
     //All of tests uses the spot price from the pool instead of the oracle

--- a/test/helpers/MockUniswapV4Wrapper.sol
+++ b/test/helpers/MockUniswapV4Wrapper.sol
@@ -60,13 +60,26 @@ contract MockUniswapV4Wrapper is UniswapV4Wrapper {
     }
 
     function pendingFees(uint256 tokenId) external view returns (uint256 fees0Owed, uint256 fees1Owed) {
-        PositionState memory positionState = _getPositionState(tokenId, true);
+        (uint160 sqrtRatioX96,,,) = poolManager.getSlot0(poolKey.toId());
+        PositionState memory positionState = _getPositionState(tokenId, sqrtRatioX96);
         return _pendingFees(positionState);
     }
 
     function total(uint256 tokenId) external view returns (uint256 amount0Total, uint256 amount1Total) {
-        PositionState memory positionState = _getPositionState(tokenId, true);
+        (uint160 sqrtRatioX96,,,) = poolManager.getSlot0(poolKey.toId());
+        PositionState memory positionState = _getPositionState(tokenId, sqrtRatioX96);
         return _total(positionState, tokenId);
+    }
+
+    struct Local {
+        uint160 sqrtRatioX96;
+        uint256 pendingFees0;
+        uint256 pendingFees1;
+        uint256 feesOwed0;
+        uint256 feesOwed1;
+        uint256 totalSupplyOfTokenId;
+        uint256 amount0;
+        uint256 amount1;
     }
 
     function calculateExactedValueOfTokenIdAfterUnwrap(
@@ -74,26 +87,52 @@ contract MockUniswapV4Wrapper is UniswapV4Wrapper {
         uint256 unwrapAmount,
         uint256 balanceBeforeUnwrap
     ) public view returns (uint256) {
-        PositionState memory positionState = _getPositionState(tokenId, true);
-        uint128 liquidityToRemove =
-            proportionalShare(positionState.liquidity, unwrapAmount, totalSupply(tokenId)).toUint128();
-
-        positionState.liquidity -= liquidityToRemove;
-
-        (uint256 amount0, uint256 amount1) = _total(positionState, tokenId);
-
-        uint256 amount0InUnitOfAccount = getQuote(amount0, _getCurrencyAddress(poolKey.currency0));
-        uint256 amount1InUnitOfAccount = getQuote(amount1, _getCurrencyAddress(poolKey.currency1));
-
-        //avoid division by zero
+        // if unwrap amount is equal to current total supply, then value after unwrap is 0
         if (totalSupply(tokenId) == unwrapAmount) {
             return 0;
         }
-        return proportionalShare(
-            amount0InUnitOfAccount + amount1InUnitOfAccount,
-            balanceBeforeUnwrap - unwrapAmount,
-            totalSupply(tokenId) - unwrapAmount
+
+        Local memory local;
+
+        // we first simulate what happens to the fees when partial unwrap is done
+        // we update the feesOwed so that after the unwrap we simply assume the pending fees are zero
+
+        (local.sqrtRatioX96,,,) = poolManager.getSlot0(poolKey.toId());
+        PositionState memory positionState = _getPositionState(tokenId, local.sqrtRatioX96);
+
+        (local.pendingFees0, local.pendingFees1) = _pendingFees(positionState);
+
+        local.feesOwed0 = tokensOwed[tokenId].fees0Owed;
+        local.feesOwed1 = tokensOwed[tokenId].fees1Owed;
+
+        local.feesOwed0 += local.pendingFees0
+        - proportionalShare(local.pendingFees0 + local.feesOwed0, unwrapAmount, totalSupply(tokenId));
+        local.feesOwed1 += local.pendingFees1
+        - proportionalShare(local.pendingFees1 + local.feesOwed1, unwrapAmount, totalSupply(tokenId));
+
+        // now we calculate the principal after the unwrap
+        positionState.liquidity -= proportionalShare(
+                uint256(positionState.liquidity), unwrapAmount, totalSupply(tokenId)
+            ).toUint128();
+
+        local.totalSupplyOfTokenId = totalSupply(tokenId) - unwrapAmount;
+
+        (local.amount0, local.amount1) = _principal(
+            positionState,
+            proportionalShare(
+                    uint256(positionState.liquidity), balanceBeforeUnwrap - unwrapAmount, local.totalSupplyOfTokenId
+                ).toUint128()
         );
+
+        local.amount0 += proportionalShare(
+            local.feesOwed0, balanceBeforeUnwrap - unwrapAmount, local.totalSupplyOfTokenId
+        );
+        local.amount1 += proportionalShare(
+            local.feesOwed1, balanceBeforeUnwrap - unwrapAmount, local.totalSupplyOfTokenId
+        );
+
+        return getQuote(local.amount0, _getCurrencyAddress(currency0))
+            + getQuote(local.amount1, _getCurrencyAddress(currency1));
     }
 
     //All of tests uses the spot price from the pool instead of the oracle

--- a/test/invariant/BaseSetup.sol
+++ b/test/invariant/BaseSetup.sol
@@ -439,4 +439,12 @@ contract BaseSetup is Test, Fuzzers {
             );
         }
     }
+
+    function getCurrentPriceX96(bool isV3) internal view returns (uint160 sqrtPriceX96) {
+        if (isV3) {
+            (sqrtPriceX96,,,,,,) = uniswapV3Wrapper.pool().slot0();
+        } else {
+            (sqrtPriceX96,,,) = poolManager.getSlot0(poolId);
+        }
+    }
 }

--- a/test/invariant/Handler.sol
+++ b/test/invariant/Handler.sol
@@ -346,7 +346,27 @@ contract Handler is Test, BaseSetup {
                 vm.expectRevert();
             }
 
-            uniswapWrapper.unwrap(currentActor, tokenId, currentActor, unwrapAmount, "");
+            {
+
+                // (uint256 previewUnwrapAmount0, uint256 previewUnwrapAmount1) =
+                //     uniswapWrapper.previewUnwrap(tokenId, getCurrentPriceX96(isV3), unwrapAmount);
+
+                // uint256 token0BalanceBeforeOfCurrentActor = token0.balanceOf(currentActor);
+                // uint256 token1BalanceBeforeOfCurrentActor = token1.balanceOf(currentActor);
+
+                uniswapWrapper.unwrap(currentActor, tokenId, currentActor, unwrapAmount, "");
+
+                // assertEq(
+                //     token0.balanceOf(currentActor),
+                //     token0BalanceBeforeOfCurrentActor + previewUnwrapAmount0,
+                //     "uniswapWrapper: unwrap should increase token0 balance of currentActor"
+                // );
+                // assertEq(
+                //     token1.balanceOf(currentActor),
+                //     token1BalanceBeforeOfCurrentActor + previewUnwrapAmount1,
+                //     "uniswapWrapper: unwrap should increase token1 balance of currentActor"
+                // );
+            }
 
             if (shouldUnwrapFail) return; //if the unwrap should fail, we can skip the rest of the assertions
         }

--- a/test/invariant/Handler.sol
+++ b/test/invariant/Handler.sol
@@ -354,6 +354,8 @@ contract Handler is Test, BaseSetup {
             local.tokenId, unwrapAmount, local.balanceBeforeUnwrap
         );
 
+        console.log("tokenIdValueBeforeUnwrap", local.tokenIdValueBeforeUnwrap);
+        console.log("expectTokenIdValueAfterUnwrap", local.expectTokenIdValueAfterUnwrap);
         //get the value of the tokenId
         local.tokenIdValueToTransfer = local.tokenIdValueBeforeUnwrap - local.expectTokenIdValueAfterUnwrap; //We are not calculating the amount directly to avoid miscalculation due to rounding error
 
@@ -541,13 +543,21 @@ contract Handler is Test, BaseSetup {
                 //TODO: why is there 1 wei of error here?
                 assertLe(
                     uniswapWrapper.balanceOf(currentActor),
-                    fromBalanceBeforeTransfer - transferAmount + 2,
+                    fromBalanceBeforeTransfer - transferAmount + 4,
                     "uniswapWrapper: transferWithoutActiveLiquidation should decrease balance of sender"
                 );
                 assertGe(
-                    uniswapWrapper.balanceOf(to) + 2,
+                    uniswapWrapper.balanceOf(to) + 4,
                     toBalanceBeforeTransfer + transferAmount,
                     "uniswapWrapper: transferWithoutActiveLiquidation should increase balance of receiver"
+                );
+                // make sure money doesn't get created out of thin air
+                // we make sure the addition of the balances before is less than the balances after the transfer
+                // due to rounding errors the balances after the transfer can be less than before by a few wei and that is expected
+                assertLe(
+                    uniswapWrapper.balanceOf(currentActor) + uniswapWrapper.balanceOf(to),
+                    fromBalanceBeforeTransfer + toBalanceBeforeTransfer + 4,
+                    "uniswapWrapper: transferWithoutActiveLiquidation should not create money out of thin air"
                 );
 
                 for (uint256 i = 0; i < localParams.tokenIds.length; i++) {

--- a/test/uniswap/UniswapV3Wrapper.t.sol
+++ b/test/uniswap/UniswapV3Wrapper.t.sol
@@ -329,7 +329,9 @@ contract UniswapV3WrapperTest is Test, UniswapBaseTest {
         wrapper.enableTokenIdAsCollateral(tokenId);
 
         assertApproxEqAbs(wrapper.balanceOf(liquidator), transferAmount, ALLOWED_PRECISION_IN_TESTS);
-        assertApproxEqRel(totalValueBefore, wrapper.balanceOf(borrower) + wrapper.balanceOf(liquidator), 1);
+        assertApproxEqRel(
+            totalValueBefore, wrapper.balanceOf(borrower) + wrapper.balanceOf(liquidator), ALLOWED_PRECISION_IN_TESTS
+        );
     }
 
     function test_BasicBorrowV3() public {

--- a/test/uniswap/UniswapV3Wrapper.t.sol
+++ b/test/uniswap/UniswapV3Wrapper.t.sol
@@ -183,12 +183,19 @@ contract UniswapV3WrapperTest is Test, UniswapBaseTest {
         uint256 amount0InUnitOfAccount = wrapper.getQuote(amount0Spent, address(token0));
         uint256 amount1InUnitOfAccount = wrapper.getQuote(amount1Spent, address(token1));
 
-        uint256 expectedBalance = (amount0InUnitOfAccount + amount1InUnitOfAccount);
+        {
+            uint256 expectedBalance = (amount0InUnitOfAccount + amount1InUnitOfAccount);
 
-        assertApproxEqAbs(wrapper.balanceOf(borrower), expectedBalance, ALLOWED_PRECISION_IN_TESTS);
+            assertApproxEqAbs(wrapper.balanceOf(borrower), expectedBalance, ALLOWED_PRECISION_IN_TESTS);
+        }
 
         uint256 amount0BalanceBefore = IERC20(token0).balanceOf(borrower);
         uint256 amount1BalanceBefore = IERC20(token1).balanceOf(borrower);
+
+        (uint160 sqrtPriceX96,,,,,,) = pool.slot0();
+        // make sure the preview unwrap matches the actual unwrap
+        (uint256 previewUnwrapAmount0, uint256 previewUnwrapAmount1) =
+            UniswapV3Wrapper(address(wrapper)).previewUnwrap(tokenId, sqrtPriceX96, wrapper.FULL_AMOUNT());
 
         //unwrap to get the underlying tokens back
         wrapper.unwrap(
@@ -200,6 +207,9 @@ contract UniswapV3WrapperTest is Test, UniswapBaseTest {
                 (amount0Spent > 0 ? amount0Spent - 1 : 0), (amount1Spent > 0 ? amount1Spent - 1 : 0), block.timestamp
             )
         );
+
+        assertEq(IERC20(token0).balanceOf(borrower), amount0BalanceBefore + previewUnwrapAmount0);
+        assertEq(IERC20(token1).balanceOf(borrower), amount1BalanceBefore + previewUnwrapAmount1);
 
         assertEq(wrapper.balanceOf(borrower, tokenId), 0);
 

--- a/test/uniswap/UniswapV4Wrapper.t.sol
+++ b/test/uniswap/UniswapV4Wrapper.t.sol
@@ -325,14 +325,21 @@ contract UniswapV4WrapperTest is Test, UniswapBaseTest {
         uint256 amount0InUnitOfAccount = wrapper.getQuote(amount0Spent, address(token0));
         uint256 amount1InUnitOfAccount = wrapper.getQuote(amount1Spent, address(token1));
 
-        uint256 expectedBalance = (amount0InUnitOfAccount + amount1InUnitOfAccount);
+        {
+            uint256 expectedBalance = (amount0InUnitOfAccount + amount1InUnitOfAccount);
 
-        assertApproxEqAbs(wrapper.balanceOf(borrower), expectedBalance, ALLOWED_PRECISION_IN_TESTS);
+            assertApproxEqAbs(wrapper.balanceOf(borrower), expectedBalance, ALLOWED_PRECISION_IN_TESTS);
+        }
 
         uint256 amount0BalanceBefore = poolKey.currency0.balanceOf(borrower);
         uint256 amount1BalanceBefore = poolKey.currency1.balanceOf(borrower);
 
         //unwrap to get the underlying tokens back
+
+        (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(poolId);
+
+        (uint256 previewUnwrapAmount0, uint256 previewUnwrapAmount1) =
+            UniswapV4Wrapper(payable(address(wrapper))).previewUnwrap(tokenId, sqrtPriceX96, wrapper.FULL_AMOUNT());
 
         wrapper.unwrap(
             borrower,
@@ -345,6 +352,10 @@ contract UniswapV4WrapperTest is Test, UniswapBaseTest {
                 block.timestamp
             )
         );
+
+        assertEq(poolKey.currency0.balanceOf(borrower), amount0BalanceBefore + previewUnwrapAmount0);
+        assertEq(poolKey.currency1.balanceOf(borrower), amount1BalanceBefore + previewUnwrapAmount1);
+
         assertEq(wrapper.balanceOf(borrower, tokenId), 0);
 
         assertApproxEqAbs(poolKey.currency0.balanceOf(borrower), amount0BalanceBefore + amount0Spent, 1);

--- a/test/uniswap/UniswapV4Wrapper.t.sol
+++ b/test/uniswap/UniswapV4Wrapper.t.sol
@@ -500,7 +500,9 @@ contract UniswapV4WrapperTest is Test, UniswapBaseTest {
         wrapper.enableTokenIdAsCollateral(tokenId);
 
         assertApproxEqAbs(wrapper.balanceOf(liquidator), transferAmount, ALLOWED_PRECISION_IN_TESTS);
-        assertApproxEqAbs(totalValueBefore, wrapper.balanceOf(borrower) + wrapper.balanceOf(liquidator), 1);
+        assertApproxEqAbs(
+            totalValueBefore, wrapper.balanceOf(borrower) + wrapper.balanceOf(liquidator), ALLOWED_PRECISION_IN_TESTS
+        );
     }
 
     function test_BasicBorrowV4() public {


### PR DESCRIPTION
Previously, we calculated amount0 and amount1 for the entire tokenId, converted them to USD, added them, and applied the proportion, reducing rounding errors for users .However, this didn't match the actual unwrap: we take the liquidity proportion first, decrease it (send the entire principal to the user), then calculate pending fees for the whole tokenId and send proportional fees.This change aligns calculations with unwrap. If spot and oracle prices match, balanceOf reflects actual unwrap tokens. 
